### PR TITLE
Create ipblacklist.sh

### DIFF
--- a/ipblacklist.sh
+++ b/ipblacklist.sh
@@ -1,0 +1,40 @@
+#! /bin/sh
+
+# Choose the level that suits you, more information found here:
+# https://github.com/stamparm/ipsum
+# https://github.com/stamparm/ipsum/tree/master/levels
+LEVEL=2
+
+# These are the default values, only adjust if it's different for your system
+IPLIST_URL="https://raw.githubusercontent.com/stamparm/ipsum/master/levels/${LEVEL}.txt"
+#IPLIST_URL="https://iplists.firehol.org/files/firehol_level1.netset"
+INSTALL_DIR="/opt/dnscrypt-proxy"
+IP_FILE="ip-blacklist.txt"
+
+FILE="${INSTALL_DIR}/${IP_FILE}"
+
+if [ "$(whoami)" != "root" ]; then
+        echo "Script doesn't have permission. Run with sudo or as root, please."
+else
+        if curl --output /dev/null --silent --head --fail "$IPLIST_URL"; then
+                if [ -f "$FILE" ]; then
+                        mv -f "${FILE}" "${FILE}.old"
+                fi
+
+                if curl "$IPLIST_URL" --output "$FILE" --silent; then
+                        rm -f "${FILE}.old"
+                        echo "IP blacklist updated."
+                        cd "$INSTALL_DIR"
+                        ./dnscrypt-proxy -service restart
+                        ./dnscrypt-proxy -service start
+                else
+                        if [ -f "${FILE}.old" ]; then
+                                mv -f "${FILE}.old" "${FILE}"
+                        fi
+                        echo "Failed to update file, possibly due to internet connection."
+                        echo "Any changes made by script have been reverted."
+                fi
+        else
+                echo "Unable to grab file from Github. Is your internet connection working?"
+        fi
+fi


### PR DESCRIPTION
This updates the "ip-blacklist.txt" file used in [dnscrypt2](https://github.com/DNSCrypt/dnscrypt-proxy) setup.
Trigger using a cronjob as per required time interval
```sh
# create crontab for root user
sudo nano crontab -e
# update ip-blacklist.txt everyday at 0430
30 4  * * *   /opt/utils/ipblacklist.sh
```